### PR TITLE
Adjust busca_cep for the API V3

### DIFF
--- a/R/busca_cep.R
+++ b/R/busca_cep.R
@@ -17,7 +17,7 @@ busca_cep <- function(cep = "01001000", token = NULL){
     stop("Um token \u00e9 preciso")
   }
 
-  url <- paste0("http://www.cepaberto.com/api/v2/ceps.json?cep=", cep)
+  url <- paste0("https://www.cepaberto.com/api/v3/cep?cep=", cep)
 
   auth <- paste0("Token token=", token)
   r <- httr::GET(url, httr::add_headers(Authorization = auth)) %>%
@@ -26,16 +26,16 @@ busca_cep <- function(cep = "01001000", token = NULL){
   N <- NA_character_
 
   CEP <- tibble::tibble(
-    estado = purrr::map_chr(r, .null = N, "estado"),
-    cidade = purrr::map_chr(r, .null = N, "cidade"),
+    estado = purrr::map_chr(r[[1]]$estado$sigla, .null = N, 1),
+    cidade = purrr::map_chr(r[[1]]$cidade$nome, .null = N, 1),
     bairro = purrr::map_chr(r, .null = N, "bairro"),
     cep = purrr::map_chr(r, .null = N, "cep"),
     logradouro = purrr::map_chr(r, .null = N, "logradouro"),
     latitude = purrr::map_chr(r, .null = N, "latitude"),
     longitude = purrr::map_chr(r, .null = N, "longitude"),
     altitude = purrr::map_chr(r, .null = N, "altitude"),
-    ddd = purrr::map_chr(r, .null = N, "ddd"),
-    cod_IBGE = purrr::map_chr(r, .null = N, "ibge")
+    ddd = purrr::map_chr(r[[1]]$cidade$ddd, .null = N, 1),
+    cod_IBGE = purrr::map_chr(r[[1]]$cidade$ibge, .null = N, 1)
   )
 
   return(CEP)

--- a/R/busca_cep.R
+++ b/R/busca_cep.R
@@ -26,8 +26,10 @@ busca_cep <- function(cep = "01001000", token = NULL){
   N <- NA_character_
 
   CEP <- tibble::tibble(
-    estado = purrr::map_chr(r[[1]]$estado$sigla, .null = N, 1),
-    cidade = purrr::map_chr(r[[1]]$cidade$nome, .null = N, 1),
+    estado = purrr::pluck(r, 1, "estado", .default = N) %>%
+             purrr::pluck("sigla", .default = N),
+    cidade = purrr::pluck(r, 1, "cidade", .default = N) %>%
+             purrr::pluck("nome", .default = N),
     bairro = purrr::map_chr(r, .null = N, "bairro"),
     cep = purrr::map_chr(r, .null = N, "cep"),
     logradouro = purrr::map_chr(r, .null = N, "logradouro"),
@@ -35,7 +37,8 @@ busca_cep <- function(cep = "01001000", token = NULL){
     longitude = purrr::map_chr(r, .null = N, "longitude"),
     altitude = purrr::map_chr(r, .null = N, "altitude"),
     ddd = purrr::map_chr(r[[1]]$cidade$ddd, .null = N, 1),
-    cod_IBGE = purrr::map_chr(r[[1]]$cidade$ibge, .null = N, 1)
+    cod_IBGE = purrr::pluck(r, 1, "cidade", .default = N) %>%
+               purrr::pluck("ibge", .default = N)
   )
 
   return(CEP)


### PR DESCRIPTION
Given the update of CEPAberto's API to the V3, here is a proposal for a fix regarding the 
`busca_cep` feature. This PR does not encompasses the other endpoints though as I had little time to work on it -- that came as a CEPAberto user that reported that cepR package was not working anymore.

It then partially addresses the #6.

Some considerations:

- There is probably a nicer way to `purrr:map` things when in a nested list as now `estado` and `cidade` are presented. So if you have something in mind please let me know.
- You may be looking for a PR that fixes at once the incompatibilities V3 introduced. That is ok, I can work on that incrementally, feel free to add some stuff if you have some time.  